### PR TITLE
Changes required for alevin-fry

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -244,7 +244,7 @@ process alevin_stats {
     
     suppressPackageStartupMessages(library(rjson))    
     
-    json <- fromJSON(file = "alevin_run/quant.json") 
+    json <- fromJSON(file = "alevin_run/meta_info.json") 
     stats <- t(data.frame(unlist(lapply(json, function(j) paste(j, collapse = ' ')))))
     run <- basename(Sys.readlink("alevin_run"))
     

--- a/main.nf
+++ b/main.nf
@@ -244,7 +244,7 @@ process alevin_stats {
     
     suppressPackageStartupMessages(library(rjson))    
     
-    json <- fromJSON(file = "alevin_run/aux_info/alevin_meta_info.json") 
+    json <- fromJSON(file = "alevin_run/quant.json") 
     stats <- t(data.frame(unlist(lapply(json, function(j) paste(j, collapse = ' ')))))
     run <- basename(Sys.readlink("alevin_run"))
     


### PR DESCRIPTION
Because alevin-fry does not produce exactly the same output files as alevin in the droplet quantification workflow, some adaptations for the workflow must be made.